### PR TITLE
[fea](cache) invalidate any path after /stats

### DIFF
--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -26,7 +26,7 @@ const updateCloudFrontCache = (canUpdateCloudfront, distributionId) => new Promi
                 Paths: {
                     Quantity: '1',
                     Items: [
-                        '/stats/',
+                        '/stats*',
                     ],
                 },
             },


### PR DESCRIPTION
Set new invalidation cloudfront rule